### PR TITLE
Added support for handling both torch.jit.ScriptModule and torch.nn.Module

### DIFF
--- a/utils_pytorch.py
+++ b/utils_pytorch.py
@@ -79,7 +79,7 @@ def get_model_path(base_path=None, experiment_name=None, make=True):
     return model_path
 
 
-def export_model(model, path=None, input_shape=(1, 3, 64, 64), use_script_module=True):
+def export_model(model, path=None, input_shape=(1, 3, 64, 64), use_script_module=False):
     """
     Exports the model. If the model is a `ScriptModule`, it is saved as is. If not,
     it is traced (with the given input_shape) and the resulting ScriptModule is saved
@@ -105,7 +105,7 @@ def export_model(model, path=None, input_shape=(1, 3, 64, 64), use_script_module
     """
     path = get_model_path() if path is None else path
     model = deepcopy(model).cpu().eval()
-    if use_torch_script:
+    if use_script_module:
         if not isinstance(model, torch.jit.ScriptModule):
             assert input_shape is not None, "`input_shape` must be provided since model is not a " \
                                             "`ScriptModule`."
@@ -119,7 +119,7 @@ def export_model(model, path=None, input_shape=(1, 3, 64, 64), use_script_module
         return path        
 
 
-def import_model(path=None, use_script_module=True):
+def import_model(path=None, use_script_module=False):
     """
     Imports a model (as ScriptModule) from file.
 

--- a/utils_pytorch.py
+++ b/utils_pytorch.py
@@ -137,7 +137,7 @@ def import_model(path=None):
     path = get_model_path() if path is None else path
     try:
         return torch.jit.load(path)
-    except:
+    except RuntimeError:
         return torch.load(path) # loads model as a nn.Module
 
 

--- a/utils_pytorch.py
+++ b/utils_pytorch.py
@@ -79,7 +79,7 @@ def get_model_path(base_path=None, experiment_name=None, make=True):
     return model_path
 
 
-def export_model(model, path=None, input_shape=(1, 3, 64, 64), use_script_module=False):
+def export_model(model, path=None, input_shape=(1, 3, 64, 64), use_script_module=True):
     """
     Exports the model. If the model is a `ScriptModule`, it is saved as is. If not,
     it is traced (with the given input_shape) and the resulting ScriptModule is saved
@@ -113,22 +113,21 @@ def export_model(model, path=None, input_shape=(1, 3, 64, 64), use_script_module
         else:
             traced_model = model
         torch.jit.save(traced_model, path)
-        return path
     else:
         torch.save(model, path) # saves model as a nn.Module
-        return path        
+        
+    return path        
 
 
-def import_model(path=None, use_script_module=False):
+def import_model(path=None):
     """
-    Imports a model (as ScriptModule) from file.
+    Imports a model (as torch.jit.ScriptModule or torch.nn.Module) from file.
+    By default the file is imported as torch.jit.ScriptModule. If it fails due to saved model being torch.nn.Module, the file is imported as torch.nn.Module.
 
     Parameters
     ----------
     path : str
         Path to where the model is saved. Defaults to the return value of the `get_model_path`
-    use_script_module : True or False (default = True)
-        If True loads model as torch.jit.ScriptModule. Else loads as a normal Module.
 
     Returns
     -------
@@ -136,9 +135,9 @@ def import_model(path=None, use_script_module=False):
         The model file.
     """
     path = get_model_path() if path is None else path
-    if use_script_module:
+    try:
         return torch.jit.load(path)
-    else:
+    except:
         return torch.load(path) # loads model as a nn.Module
 
 

--- a/utils_pytorch.py
+++ b/utils_pytorch.py
@@ -79,7 +79,7 @@ def get_model_path(base_path=None, experiment_name=None, make=True):
     return model_path
 
 
-def export_model(model, path=None, input_shape=(1, 3, 64, 64)):
+def export_model(model, path=None, input_shape=(1, 3, 64, 64), use_script_module=True):
     """
     Exports the model. If the model is a `ScriptModule`, it is saved as is. If not,
     it is traced (with the given input_shape) and the resulting ScriptModule is saved
@@ -95,6 +95,8 @@ def export_model(model, path=None, input_shape=(1, 3, 64, 64)):
     input_shape : tuple or list
         Shape of the input to trace the module with. This is only required if model is not a
         torch.jit.ScriptModule.
+    use_script_module : True or False (default = True)
+        If True saves model as torch.jit.ScriptModule. Else saves as a normal Module.
 
     Returns
     -------
@@ -103,17 +105,21 @@ def export_model(model, path=None, input_shape=(1, 3, 64, 64)):
     """
     path = get_model_path() if path is None else path
     model = deepcopy(model).cpu().eval()
-    if not isinstance(model, torch.jit.ScriptModule):
-        assert input_shape is not None, "`input_shape` must be provided since model is not a " \
-                                        "`ScriptModule`."
-        traced_model = trace(model, torch.zeros(*input_shape))
-    else:
-        traced_model = model
-    torch.jit.save(traced_model, path)
-    return path
+    if use_torch_script:
+        if not isinstance(model, torch.jit.ScriptModule):
+            assert input_shape is not None, "`input_shape` must be provided since model is not a " \
+                                            "`ScriptModule`."
+            traced_model = trace(model, torch.zeros(*input_shape))
+        else:
+            traced_model = model
+        torch.jit.save(traced_model, path)
+        return path
+    else:
+        torch.save(model, path) # saves model as a nn.Module
+        return path        
 
 
-def import_model(path=None):
+def import_model(path=None, use_script_module=True):
     """
     Imports a model (as ScriptModule) from file.
 
@@ -121,15 +127,19 @@ def import_model(path=None):
     ----------
     path : str
         Path to where the model is saved. Defaults to the return value of the `get_model_path`
-        function above.
+    use_script_module : True or False (default = True)
+        If True loads model as torch.jit.ScriptModule. Else loads as a normal Module.
 
     Returns
     -------
-    torch.jit.ScriptModule
+    torch.jit.ScriptModule / torch.nn.Module
         The model file.
     """
     path = get_model_path() if path is None else path
-    return torch.jit.load(path)
+    if use_script_module:
+        return torch.jit.load(path)
+    else:
+        return torch.load(path) # loads model as a nn.Module
 
 
 def make_representor(model, cuda=None):


### PR DESCRIPTION
Added support for handling both torch.jit.ScriptModule and torch.nn.Module. 

Reason : some functionalities are not yet supported in torchscript leading to errors. 
Hence the support to save the model as a nn.Module.